### PR TITLE
remove storeScores([s]) from runMatrix (already in itRunMatrix)

### DIFF
--- a/benchmark/lib/index.js
+++ b/benchmark/lib/index.js
@@ -121,10 +121,6 @@ export const runMatrix = async (name, json, matrix, checks, options) => {
     console.log(JSON.stringify(copy, null, 2));
 
     scores.push(s);
-
-    if (options?.shouldSave) {
-      await storeScores([s]);
-    }
   }
 
   return scores;


### PR DESCRIPTION
Removes extra storeScores call, should help with rate limits as well.