### PR TITLE
extract benchmark updates, local summary

### DIFF
--- a/benchmark/extract/ct.curaleaf.com-extract.bench.js
+++ b/benchmark/extract/ct.curaleaf.com-extract.bench.js
@@ -1,0 +1,231 @@
+import { fox } from '../../src/index.js';
+import { itRunMatrix, runMatrix } from '../lib/index.js';
+import { standardMatrix } from '../lib/matrix.js';
+import { checkItemsAI } from '../lib/checks.js';
+
+describe('extract ct.curaleaf.com', async function() {
+  const matrix = standardMatrix();
+
+  const expected = [
+    {
+      product_name: 'Curaleaf Whole Flower A Tartz (H) 00522',
+      product_weight: '1/8oz',
+      product_strength: '31.02% THCA • 27.83% Total THC',
+      product_description: 'Curaleaf Whole Flower A Tartz',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Ivory (H) 00533',
+      product_weight: '1/8oz',
+      product_strength: '28.7% THCA • 26.04% Total THC',
+      product_description: 'Curaleaf Whole Flower Ivory',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Banana Papaya (S) 00441',
+      product_weight: '1/8oz',
+      product_strength: '25.24% THCA • 22.46% Total THC',
+      product_description: 'Curaleaf Whole Flower Banana Papaya',
+      product_strain: 'Sativa',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Slip (I) 00354',
+      product_weight: '1/8oz',
+      product_strength: '21.86% THCA • 19.54% Total THC',
+      product_description: 'Curaleaf Whole Flower Slip',
+      product_strain: 'Indica',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Indica Princess (I) 00246',
+      product_weight: '1/8oz',
+      product_strength: '21.35% THCA • 18.98% Total THC',
+      product_description: 'Curaleaf Whole Flower Indica Princess',
+      product_strain: 'Indica',
+      product_price: '$32'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower GSC (H) 00399',
+      product_weight: '1/8oz',
+      product_strength: '19.09% THCA • 17.09% Total THC',
+      product_description: 'Curaleaf Whole Flower GSC',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Montana Silvertip (H) 00391',
+      product_weight: '1/8oz',
+      product_strength: '22.67% THCA • 20.17% Total THC',
+      product_description: 'Curaleaf Whole Flower Montana Silvertip',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Ground Flower BCG (S) 00524',
+      product_weight: '1/8oz',
+      product_strength: '17.54% THCA • 15.51% Total THC',
+      product_description: 'Curaleaf Ground Flower BCG',
+      product_strain: 'Sativa',
+      product_price: '$26'
+    },
+    {
+      product_name: 'Curaleaf Ground Flower Teal (H) 00001',
+      product_weight: '1/8oz',
+      product_strength: '17.62% THCA • 15.72% Total THC',
+      product_description: 'Curaleaf Ground Flower Teal',
+      product_strain: 'Hybrid',
+      product_price: '$32'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Orange Z (S) 00294',
+      product_weight: '1/8oz',
+      product_strength: '21.07% Total THC • 20.43% THCA',
+      product_description: 'Curaleaf Whole Flower Orange Z',
+      product_strain: 'Sativa',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Carmelita (I) 00581',
+      product_weight: '1/8oz',
+      product_strength: '25.91% THCA • 23.14% Total THC',
+      product_description: 'Curaleaf Whole Flower Carmelita',
+      product_strain: 'Indica',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Mr E Pupil (S) 00289',
+      product_weight: '1/8oz',
+      product_strength: '23.46% THCA • 20.58% Total THC',
+      product_description: 'Curaleaf Whole Flower Mr E Pupil',
+      product_strain: 'Sativa',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Ground Flower Indica Princess (I) 00417',
+      product_weight: '1/8oz',
+      product_strength: '17.29% THCA • 15.2% Total THC',
+      product_description: 'Curaleaf Ground Flower Indica Princess',
+      product_strain: 'Indica',
+      product_price: '$24'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Raspberry P (S) 00169',
+      product_weight: '1/8oz',
+      product_strength: '18.48% THCA • 15.27% Total THC',
+      product_description: 'Curaleaf Whole Flower Raspberry P',
+      product_strain: 'Sativa',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Apes In Space (I) 00348',
+      product_weight: '1/8oz',
+      product_strength: '19.62% THCA • 17.57% Total THC',
+      product_description: 'Curaleaf Whole Flower Apes In Space',
+      product_strain: 'Indica',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Whole Flower - Novarine (S) 23983',
+      product_weight: '1/8oz',
+      product_strength: '23.13% THCA • 20.61% Total THC',
+      product_description: 'Whole Flower - Novarine',
+      product_strain: 'Sativa',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower PBB (H) 00398',
+      product_weight: '1/8oz',
+      product_strength: '20.92% THCA • 19.04% Total THC',
+      product_description: 'Curaleaf Whole Flower PBB',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Minium (I) 00577',
+      product_weight: '1/8oz',
+      product_strength: '30.78% THCA • 27.31% Total THC',
+      product_description: 'Curaleaf Whole Flower Minium',
+      product_strain: 'Indica',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Auburn (H) 00580',
+      product_weight: '1/8oz',
+      product_strength: '31.05% THCA • 27.77% Total THC',
+      product_description: 'Curaleaf Whole Flower Auburn',
+      product_strain: 'Hybrid',
+      product_price: '$34'
+    },
+    {
+      product_name: 'Curaleaf Ground Flower BC (I) 00575',
+      product_weight: '1/8oz',
+      product_strength: '20.17% THCA • 18.04% Total THC',
+      product_description: 'Curaleaf Ground Flower BC',
+      product_strain: 'Indica',
+      product_price: '$26'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower A Tartz (H) 00522',
+      product_weight: '1/8oz',
+      product_strength: '31.02% THCA • 27.83% Total THC',
+      product_description: 'Curaleaf Whole Flower A Tartz',
+      product_strain: 'Hybrid',
+      product_price: '(not found)'
+    },
+    {
+      product_name: 'Curaleaf Whole Flower Banana Papaya (S) 00441',
+      product_weight: '1/8oz',
+      product_strength: '25.24% THCA • 22.46% Total THC',
+      product_description: 'Curaleaf Whole Flower Banana Papaya',
+      product_strain: 'Sativa',
+      product_price: '(not found)'
+    }
+  ];
+
+  const cases = [
+    {
+      name: 'live',
+      url: 'https://ct.curaleaf.com/shop/connecticut/curaleaf-ct-stamford/categories/flower',
+      expected: [],
+    },
+    {
+      name: 'saved',
+      url: 'https://ffcloud.s3.us-west-2.amazonaws.com/fetchfox-docs/93ue3wfv78/https-ct-curaleaf-com-shop-connecticut-curaleaf-ct-stamford-categories-flower.html',
+      expected,
+    },
+  ];
+
+  const questions = {
+    product_name: 'name of the product being sold',
+    product_weight: 'weight of the product usually in grams ',
+    product_strength: 'percentages of THC / CBD',
+    product_description: 'answers the question, what is being sold? for example sour diesel',
+    product_strain: 'hybrid, indica, or sativa',
+    product_price: 'the cost of the flower product in dollars'
+  }
+
+  for (const { name, url, expected } of cases) {
+    const wf = await fox
+      .init(url)
+      .extract({
+        questions,
+        mode: 'multiple',
+        view: 'html',
+      })
+      .limit(25)
+      .plan();
+
+    await itRunMatrix(
+      it,
+      `extract ct.curaleaf.com (${name})`,
+      wf.dump(),
+      matrix,
+      [
+        (items) => checkItemsAI(items, expected, questions),
+      ],
+      { shouldSave: true });
+  }
+});

--- a/benchmark/extract/pokemondb.net.bench.js
+++ b/benchmark/extract/pokemondb.net.bench.js
@@ -1,8 +1,7 @@
 import { fox } from '../../src/index.js';
 import { itRunMatrix, runMatrix } from '../lib/index.js';
 import { standardMatrix } from '../lib/matrix.js';
-import { checkItemsExact } from '../lib/checks.js';
-import { storeScores } from '../lib/store.js';
+import { checkItemsAI } from '../lib/checks.js';
 
 describe('extract from https://silvercreekrealty.net/silvercreek-agent-directory', async function() {
   const matrix = standardMatrix({
@@ -36,23 +35,40 @@ describe('extract from https://silvercreekrealty.net/silvercreek-agent-directory
     },
   ];
 
-  const wf = await fox
-    .init('https://pokemondb.net/pokedex/national')
-    .extract({
-      name:	'What is the name of this pokemon?',
-      number: 'What is the pokemon number',
-      url: `What is the URL of the pokemon`,
-    })
-    .limit(5)
-    .plan();
+  const cases = [
+    {
+      name: 'live',
+      url: 'https://pokemondb.net/pokedex/national',
+      expected,
+    },
+    {
+      name: 'saved',
+      url: 'https://ffcloud.s3.us-west-2.amazonaws.com/fetchfox-docs/djh6e69cux/https-pokemondb-net-pokedex-national.html',
+      expected,
+    },
+  ];
 
-  return itRunMatrix(
-    it,
-    'extract pokemon from pokemondb.net/pokedex/national',
-    wf.dump(),
-    matrix,
-    [
-      (items) => checkItemsExact(items, expected),
-    ],
-    { shouldSave: true });
+  const questions = {
+    name:	'What is the name of this pokemon?',
+    number: 'What is the pokemon number',
+    url: `What is the URL of the pokemon`,
+  }
+
+  for (const { name, url, expected } of cases) {
+    const wf = await fox
+      .init(url)
+      .extract({ questions })
+      .limit(5)
+      .plan();
+
+    return itRunMatrix(
+      it,
+      `extract pokemon from pokemondb.net/pokedex/national (${name})`,
+      wf.dump(),
+      matrix,
+      [
+        (items) => checkItemsAI(items, expected, questions),
+      ],
+      { shouldSave: true });
+  }
 });

--- a/benchmark/extract/scotchwhiskyauctions.com-extract.bench.js
+++ b/benchmark/extract/scotchwhiskyauctions.com-extract.bench.js
@@ -1,8 +1,7 @@
 import { fox } from '../../src/index.js';
 import { itRunMatrix, runMatrix } from '../lib/index.js';
 import { standardMatrix } from '../lib/matrix.js';
-import { checkItemsExact } from '../lib/checks.js';
-import { storeScores } from '../lib/store.js';
+import { checkItemsAI } from '../lib/checks.js';
 
 describe('scotchwhiskyauctions.com', async function() {
   const matrix = standardMatrix();
@@ -12,27 +11,45 @@ describe('scotchwhiskyauctions.com', async function() {
     bottle_size: '70cl',
     current_bid: '£210',
   };
-  const wf = await fox
-    .init(`https://www.scotchwhiskyauctions.com/auctions/213-the-164th-auction/790441-sideburn-31-year-old-blended-malt-whisky-sponge-edition-no95/`)
-    .extract({
-      questions: {
-        item_name: 'What is the name of the auction item?',
-        bottle_size: 'What is the size of the bottle?',
-        current_bid: 'What is the current bid for the item?'
-      },
-      hint: 'Agree to age verification',
-      maxPages: 1,
-      mode: 'single',
-    })
-    .plan();
 
-  await itRunMatrix(
-    it,
-    'extract from scotchwhiskyauctions.com',
-    wf.dump(),
-    matrix,
-    [
-      (items) => checkItemsExact(items, [expected], ['item_name', 'bottle_size', 'current_bid'])
-    ],
-    { shouldSave: true });
+  const cases = [
+    {
+      name: 'live',
+      url: 'https://www.scotchwhiskyauctions.com/auctions/213-the-164th-auction/790441-sideburn-31-year-old-blended-malt-whisky-sponge-edition-no95/',
+      expected,
+    },
+    {
+      name: 'saved',
+      url: 'https://ffcloud.s3.us-west-2.amazonaws.com/fetchfox-docs/bw4guc2zyo/https-www-scotchwhiskyauctions-com-auctions-213-the-164th-auction-790441-sideburn-31-year-old-blended-malt-whisky-sponge-edition-no95-.html',
+      expected,
+    },
+  ];
+
+  const questions = {
+    item_name: 'What is the name of the auction item?',
+    bottle_size: 'What is the size of the bottle?',
+    current_bid: 'What is the current bid for the item?'
+  }
+
+  for (const { name, url, expected } of cases) {
+    const wf = await fox
+      .init(url)
+      .extract({
+        questions,
+        hint: 'Agree to age verification',
+        maxPages: 1,
+        mode: 'single',
+      })
+      .plan();
+
+    await itRunMatrix(
+      it,
+      `extract from scotchwhiskyauctions.com (${name})`,
+      wf.dump(),
+      matrix,
+      [
+        (items) => checkItemsAI(items, [expected], questions, ['item_name', 'bottle_size', 'current_bid'])
+      ],
+      { shouldSave: true });
+  }
 });

--- a/benchmark/extract/youtube.com-comments.bench.js
+++ b/benchmark/extract/youtube.com-comments.bench.js
@@ -2,7 +2,6 @@ import { fox } from '../../src/index.js';
 import { itRunMatrix, runMatrix } from '../lib/index.js';
 import { standardMatrix } from '../lib/matrix.js';
 import { checkItemsAI } from '../lib/checks.js';
-import { storeScores } from '../lib/store.js';
 
 describe('youtube.com comments', async function() {
   const matrix = standardMatrix();
@@ -41,14 +40,16 @@ describe('youtube.com comments', async function() {
     },
   ];
 
+  const questions = {
+    comment_text: 'What is the text of the comment? List them in order, starting with the first comment',
+    comment_author: 'Who is the author of the comment?',
+  }
+
   for (const { name, url, expected } of cases) {
     const wf = await fox
       .init(url)
       .extract({
-        questions: {
-          comment_text: 'What is the text of the comment? List them in order, starting with the first comment',
-          comment_author: 'Who is the author of the comment?',
-        },
+        questions,
         mode: 'multiple',
         view: 'html',
       })
@@ -61,7 +62,7 @@ describe('youtube.com comments', async function() {
       wf.dump(),
       matrix,
       [
-        (items) => checkItemsAI(items, expected, ['comment_text', 'comment_author']),
+        (items) => checkItemsAI(items, expected, questions),
       ],
       { shouldSave: true });
   }

--- a/benchmark/extract/youtube.com.bench.js
+++ b/benchmark/extract/youtube.com.bench.js
@@ -1,8 +1,7 @@
 import { fox } from '../../src/index.js';
 import { itRunMatrix, runMatrix } from '../lib/index.js';
 import { standardMatrix } from '../lib/matrix.js';
-import { checkItemsExact } from '../lib/checks.js';
-import { storeScores } from '../lib/store.js';
+import { checkItemsAI } from '../lib/checks.js';
 
 describe('extract from youtube.com', async function() {
   const matrix = standardMatrix({});
@@ -31,24 +30,26 @@ describe('extract from youtube.com', async function() {
     },
   ];
 
+  const questions = {
+    title: 'What is the title of this video?',
+    creator: 'Who is the creator of this video?',
+  }
+
   for (const { id, expected } of cases) {
     const wf = await fox
       .init(`https://www.youtube.com/watch?v=${id}`)
       .extract({
-        questions: {
-          title: 'What is the title of this video?',
-          creator: 'Who is the creator of this video?',
-        },
+        questions,
         single: true
       })
       .plan();
     await itRunMatrix(
       it,
-      `extract title and creator from youtube.com video id=${id}`,
+      `extract title and creator from youtube.com video`,
       wf.dump(),
       matrix,
       [
-        (items) => checkItemsExact(items, [expected]),
+        (items) => checkItemsAI(items, [expected], questions),
       ],
       { shouldSave: true });
   }

--- a/benchmark/lib/matrix.js
+++ b/benchmark/lib/matrix.js
@@ -54,9 +54,10 @@ export const createMatrix = (configs, options) => {
         const updated = { ...existing };
         updated[key] = val;
         if (key == 'fetcher') {
+          // val[1].wait = 10 * 1000;
           if (cdp && (options?.useCdp || process.env.BENCH_USE_CDP)) {
             val[1].cdp = cdp;
-            val[1].timeout = 120 * 1000; // long timeouts for proxy providers
+            val[1].timeout = 120 * 1000;
           }
         }
         newMatrix.push(updated);


### PR DESCRIPTION
Added cases 'live' and 'saved' to most extract benchmarks.
Updated checkItemsAI scoring method to be mostly comparable to percent matched (but with partial credit for close matches).
Pass questions to checkItemsAI to help check if output format requested is ambiguous.
Added summary aggregation to benchmarks when run locally.

Expected values may still need to be updated