### PR TITLE
[Bug]: The apikey is not detected through the constructor

### DIFF
--- a/src/ai/BaseAI.js
+++ b/src/ai/BaseAI.js
@@ -17,14 +17,14 @@ export const BaseAI = class {
       apiKey,
       advanced,
     } =
-    Object.assign(
-      {
-        maxRetries: 10,
-        retryMsec: 5000,
-        model: this.constructor.defaultModel,
-        apiKey: (apiKeyEnvVariable ? process.env[apiKeyEnvVariable] : null),
-      },
-      options);
+      Object.assign(
+        {
+          maxRetries: 10,
+          retryMsec: 5000,
+          model: this.constructor.defaultModel,
+          apiKey: (apiKeyEnvVariable ? process.env[apiKeyEnvVariable] : null),
+        },
+        options);
 
     if (cache) this.cache = cache;
     this.logger = logger || defaultLogger;
@@ -58,7 +58,7 @@ export const BaseAI = class {
       tokens: { input: 0, output: 0, total: 0 },
       cost: { input: 0, output: 0, total: 0 },
       runtime: { sec: 0, msec: 0 },
-      requests: { attempts: 0, errors: 0, failures: 0  },
+      requests: { attempts: 0, errors: 0, failures: 0 },
     }
 
     this.baseURL = options?.baseURL;
@@ -135,6 +135,10 @@ export const BaseAI = class {
   }
 
   async *stream(prompt, options) {
+    if (!this.apiKey && !this.constructor.optionalApiKey) {
+      throw new Error(`FetchFox is missing API key for ${this.constructor.name}. Enter it using environment variable ${this.constructor.apiKeyEnvVariable} or pass it in to the constructor`);
+    }
+
     await this.init();
 
     let tokens;
@@ -274,14 +278,14 @@ export const BaseAI = class {
 
     let result;
     let retries = Math.min(this.maxRetries, options?.retries ?? 2);
-    const retryMsec= 5000;
+    const retryMsec = 5000;
     while (true) {
       try {
         for await (const chunk of this.stream(prompt, options)) {
           result = chunk;
         }
 
-      } catch(e) {
+      } catch (e) {
         this.logger.error(`Caught ${this} error: ${e}`);
 
         if (!e.status || --retries <= 0) {

--- a/src/ai/BaseAI.js
+++ b/src/ai/BaseAI.js
@@ -26,10 +26,6 @@ export const BaseAI = class {
       },
       options);
 
-    if (!apiKey && !this.constructor.optionalApiKey) {
-      throw new Error(`FetchFox is missing API key for ${this.constructor.name}. Enter it using environment variable ${apiKeyEnvVariable} or pass it in to the constructor`);
-    }
-
     if (cache) this.cache = cache;
     this.logger = logger || defaultLogger;
 

--- a/src/workflow/Workflow.js
+++ b/src/workflow/Workflow.js
@@ -19,7 +19,7 @@ export const Workflow = class extends BaseWorkflow {
 
   toString() {
     const len = (this.steps || []).length;
-    return `[${this.constructor.name}: ${len} step${len == 1 ? '' : 's'}]`;
+    return `[${this.constructor.name}: ${len} step${len == 1 ? '' : 's'}]`
   }
 
   async describe() {
@@ -38,7 +38,7 @@ export const Workflow = class extends BaseWorkflow {
     }
 
     const planner = new Planner(this.ctx);
-    let planPromise;
+    let planPromise
 
     if (args.prompt != undefined) {
       this.ctx.logger.debug(`Plan workflow from prompt`);
@@ -107,7 +107,7 @@ export const Workflow = class extends BaseWorkflow {
       this.ctx.signal = null;
       abortListener = () => {
         this.controller.abort();
-      };
+      }
       ctxSignal.addEventListener('abort', abortListener);
     }
     this.ctx.update({ signal: this.controller.signal });
@@ -126,7 +126,7 @@ export const Workflow = class extends BaseWorkflow {
       }
     }
 
-    const msg = ` Starting workflow with ${this.steps.length} steps: ${this.steps.map(s => ('' + s).replace('Step', '')).join(' -> ')} `;
+    const msg = ` Starting workflow with ${this.steps.length} steps: ${this.steps.map(s => (''+s).replace('Step', '')).join(' -> ')} `;
     this.ctx.logger.info('╔' + '═'.repeat(msg.length) + '╗');
     this.ctx.logger.info('║' + msg + '║');
     this.ctx.logger.info('╚' + '═'.repeat(msg.length) + '╝');
@@ -157,10 +157,10 @@ export const Workflow = class extends BaseWorkflow {
     }
     this.controller.abort();
   }
-};
+}
 
 for (const stepName of stepNames) {
-  Workflow.prototype[stepName] = function (prompt) {
+  Workflow.prototype[stepName] = function(prompt) {
     const name = stepName;
     const cls = classMap[name];
 
@@ -216,5 +216,5 @@ for (const stepName of stepNames) {
     }
 
     return this.step({ name, args: prompt });
-  };
+  }
 }

--- a/src/workflow/Workflow.js
+++ b/src/workflow/Workflow.js
@@ -14,12 +14,18 @@ export const Workflow = class extends BaseWorkflow {
 
   config(args) {
     this.ctx.update(args);
+
+    if (!this.ctx.ai.apiKey) {
+      throw new Error(
+        `FetchFox is missing API key for ${this.ctx.ai.constructor.name}. Enter it using environment variable ${this.ctx.ai.constructor.apiKeyEnvVariable} or pass it in to the constructor`);
+    }
+
     return this;
   }
 
   toString() {
     const len = (this.steps || []).length;
-    return `[${this.constructor.name}: ${len} step${len == 1 ? '' : 's'}]`
+    return `[${this.constructor.name}: ${len} step${len == 1 ? '' : 's'}]`;
   }
 
   async describe() {
@@ -38,7 +44,7 @@ export const Workflow = class extends BaseWorkflow {
     }
 
     const planner = new Planner(this.ctx);
-    let planPromise
+    let planPromise;
 
     if (args.prompt != undefined) {
       this.ctx.logger.debug(`Plan workflow from prompt`);
@@ -107,7 +113,7 @@ export const Workflow = class extends BaseWorkflow {
       this.ctx.signal = null;
       abortListener = () => {
         this.controller.abort();
-      }
+      };
       ctxSignal.addEventListener('abort', abortListener);
     }
     this.ctx.update({ signal: this.controller.signal });
@@ -126,7 +132,7 @@ export const Workflow = class extends BaseWorkflow {
       }
     }
 
-    const msg = ` Starting workflow with ${this.steps.length} steps: ${this.steps.map(s => (''+s).replace('Step', '')).join(' -> ')} `;
+    const msg = ` Starting workflow with ${this.steps.length} steps: ${this.steps.map(s => ('' + s).replace('Step', '')).join(' -> ')} `;
     this.ctx.logger.info('╔' + '═'.repeat(msg.length) + '╗');
     this.ctx.logger.info('║' + msg + '║');
     this.ctx.logger.info('╚' + '═'.repeat(msg.length) + '╝');
@@ -157,10 +163,10 @@ export const Workflow = class extends BaseWorkflow {
     }
     this.controller.abort();
   }
-}
+};
 
 for (const stepName of stepNames) {
-  Workflow.prototype[stepName] = function(prompt) {
+  Workflow.prototype[stepName] = function (prompt) {
     const name = stepName;
     const cls = classMap[name];
 
@@ -216,5 +222,5 @@ for (const stepName of stepNames) {
     }
 
     return this.step({ name, args: prompt });
-  }
+  };
 }

--- a/src/workflow/Workflow.js
+++ b/src/workflow/Workflow.js
@@ -14,12 +14,6 @@ export const Workflow = class extends BaseWorkflow {
 
   config(args) {
     this.ctx.update(args);
-
-    if (!this.ctx.ai.apiKey) {
-      throw new Error(
-        `FetchFox is missing API key for ${this.ctx.ai.constructor.name}. Enter it using environment variable ${this.ctx.ai.constructor.apiKeyEnvVariable} or pass it in to the constructor`);
-    }
-
     return this;
   }
 


### PR DESCRIPTION
So, if you use this piece of code:
```
const wf = fox
        .config({
            ai: ['openai:gpt-4o-mini',
                { apiKey: '<key>' }
            ]
        })
        .init('https://pokemondb.net/pokedex/national')
        .extract({ name: 'Pokemon name', number: 'Pokemon number' })
```
it leads to an error, even though the API key is specified according to the documentation because the check is happening at the wrong place.
The API keys are set inside workflow's config method, not in the constructor.